### PR TITLE
Change of deltaTMin and deltaTChem is updated with ISAT

### DIFF
--- a/Allwmake
+++ b/Allwmake
@@ -136,6 +136,11 @@ pushd tests/validation/pyjacTests/PSRTest  > /dev/null
     ./runTests.sh
 popd  > /dev/null
 
+pushd tests/validation/isatTests > /dev/null
+    ./test.sh
+popd  > /dev/null
+
+
 cp -r utilities/mechanisms/yao tutorials/multicomponentFluid/shearlayer_DLB_pyJac/pyJac
 cp utilities/CMakeLists.txt tutorials/multicomponentFluid/shearlayer_DLB_pyJac/pyJac/lib/
 cp utilities/runCmake.sh tutorials/multicomponentFluid/shearlayer_DLB_pyJac/pyJac/lib/

--- a/src/thermophysicalModels/chemistryModel/chemistryModel/loadBalancedChemistryModel/loadBalancedChemistryModel.H
+++ b/src/thermophysicalModels/chemistryModel/chemistryModel/loadBalancedChemistryModel/loadBalancedChemistryModel.H
@@ -114,6 +114,9 @@ private:
         //- Update the reaction rates from a list of solutions
         scalar updateReactionRates(const RecvBuffer<ChemistrySolution>& solutions);
 
+        //- Update the deltaTMin and deltaTChem from a solution
+        void updateDeltaT(const ChemistrySolution& solution, scalar& deltaTMin);
+
         //- Try to retrieve the candidate problem from the ISAT tree
         bool retrieveProblem(ChemistryProblem& problem, scalarField& phiq, scalarField& Rphiq) const;
         void tabulateProblem(ChemistryProblem& problem, scalarField& phiq, scalarField& Rphiq) const;

--- a/src/thermophysicalModels/chemistryModel/loadBalancing/ChemistrySolution.H
+++ b/src/thermophysicalModels/chemistryModel/loadBalancing/ChemistrySolution.H
@@ -1,8 +1,8 @@
 /*---------------------------------------------------------------------------*\
   =========                 |
-  \\      /  F ield         | DLBFoam: Dynamic Load Balancing 
+  \\      /  F ield         | DLBFoam: Dynamic Load Balancing
    \\    /   O peration     | for fast reactive simulations
-    \\  /    A nd           | 
+    \\  /    A nd           |
      \\/     M anipulation  | 2020, Aalto University, Finland
 -------------------------------------------------------------------------------
 License
@@ -23,7 +23,7 @@ License
 
 Class
     Foam::ChemistrySolution
-    
+
 Description
     A small object containing everything required for updating the reaction rate
     and the chemistry time step. These are passed around in the load balancer.
@@ -44,7 +44,7 @@ struct ChemistrySolution
     ChemistrySolution() = default;
 
     ChemistrySolution(label nspecie)
-        : rr(nspecie, 0.0), deltaTChem(0.0), cellid(0), rhoi(0.0)
+        : rr(nspecie, 0.0), deltaTChem(0.0), cellid(0), rhoi(0.0), retrieved(false)
     {
     }
 
@@ -63,6 +63,7 @@ struct ChemistrySolution
     scalar cpuTime;
     label cellid;
     scalar rhoi;
+    bool retrieved;
 };
 
 //- Serialization for send
@@ -73,6 +74,7 @@ static inline Ostream& operator<<(Ostream& os, const ChemistrySolution& s)
     os << s.cpuTime;
     os << s.cellid;
     os << s.rhoi;
+    os << s.retrieved;
     return os;
 }
 
@@ -84,6 +86,7 @@ static inline Istream& operator>>(Istream& is, ChemistrySolution& s)
     is >> s.cpuTime;
     is >> s.cellid;
     is >> s.rhoi;
+    is >> s.retrieved;
     return is;
 }
 

--- a/tests/validation/isatTests/README.md
+++ b/tests/validation/isatTests/README.md
@@ -1,0 +1,18 @@
+# ISAT-DLBFoam Coupling Validation Script
+
+This script validates the ISAT-DLBFoam coupling on a chemFoam test case. It performs the following steps:
+
+1. Copies the necessary files from $WM_PROJECT_DIR/test/chemistry/gri to a local directory 'gri'.
+2. Converts chemistry files using chemkinToFoam.
+3. Configures ISAT settings in constant/chemistryProperties.
+4. Runs chemFoam with standard implementation and stores results.
+5. Runs chemFoam with DLBFoam implementation and stores results.
+6. Compares the outputs from standard and DLB implementations using a unit test.
+
+## Dependencies
+
+- OpenFOAM environment with necessary libraries and tools.
+
+## Usage
+
+Ensure that your OpenFOAM environment is properly set up and configured. Modify paths and settings in the script as necessary to match your specific setup.

--- a/tests/validation/isatTests/test.sh
+++ b/tests/validation/isatTests/test.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+NC='\e[0m' # No Color
+GREEN='\e[1;32m'
+YELLOW='\e[1;33m'
+DARKGRAY='\e[1;30m'
+
+echo -e "${YELLOW}Validate ISAT-DLBFoam coupling on a chemFoam test:${DARKGRAY}"
+
+# Source tutorial run functions
+. $WM_PROJECT_DIR/bin/tools/RunFunctions
+
+# Redirect all output to /dev/null
+exec > /dev/null 2>&1
+
+rm -rf gri
+cp -r $WM_PROJECT_DIR/test/chemistry/gri .
+
+cd gri
+
+    application=$(getApplication)
+
+    runApplication chemkinToFoam \
+                chemkin/chem.inp chemkin/therm.dat chemkin/transportProperties \
+                constant/reactions constant/speciesThermo
+
+    # Set ISAT
+    sed -i '/chemistry       on;/a#includeEtc     "caseDicts/solvers/chemistry/TDAC/chemistryPropertiesFlame.cfg"\n#remove         reduction' constant/chemistryProperties
+    foamDictionary -expand -entry tabulation/tolerance -set 1e-5 constant/chemistryProperties
+
+    # Test standard implementation
+    runApplication -s standard chemFoam
+    mv chemFoam.out chemFoam_standard.out
+    (cd validation && ./Allrun $*)
+    cp validation/OF_vs_CHEMKINII.eps OF_vs_CHEMKINII_standard.eps
+
+    # Test DLB
+    foamDictionary -entry libs -set '("libchemistryModel_DLB.so" )' system/controlDict
+    foamDictionary -entry loadbalancing -set {} constant/chemistryProperties
+    foamDictionary -entry loadbalancing/active -add false constant/chemistryProperties
+    foamDictionary -entry refmapping -set {} constant/chemistryProperties
+    foamDictionary -entry refmapping/active -add false constant/chemistryProperties
+
+    foamDictionary -entry chemistryType/method -set loadBalanced constant/chemistryProperties
+    runApplication -s DLB chemFoam
+    mv chemFoam.out chemFoam_DLB.out
+    (cd validation && ./Allrun $*)
+    cp validation/OF_vs_CHEMKINII.eps OF_vs_CHEMKINII_DLB_ISAT.eps
+
+    # Re-enable output for the unit test
+    exec > /dev/tty 2>&1
+
+    # Unit test to compare outputs
+    if diff chemFoam_standard.out chemFoam_DLB.out > /dev/null ; then
+         echo -e "${GREEN}PASSED.${NC}"
+    else
+        echo -e "${RED}FAILED. Check the ISAT-DLBFoam implementation.${NC}"
+    fi
+
+cd ../
+
+rm -rf gri

--- a/tests/validation/pyjacTests/PSRTest/runTests.sh
+++ b/tests/validation/pyjacTests/PSRTest/runTests.sh
@@ -8,7 +8,6 @@ echo
 echo -e "${YELLOW}Validate pyJac chemistry module against reference data on perfectly stirred reactor:${DARKGRAY}"
 echo
 
-foamDictionary -entry tabulation/method -set none testCase/constant/chemistryProperties > /dev/null
 
 ./PSRTest.bin -case testCase | tee testCase/log.orig
 
@@ -46,7 +45,9 @@ else
     echo -e "${RED}You may still use DLBFoam with thermo properties that are precompiled in OpenFOAM.${NC}"
 fi
 
-
+cp testCase/constant/chemistryProperties testCase/constant/chemistryProperties.orig
+foamDictionary  testCase/constant/chemistryProperties -entry '#includeEtc' -add '"caseDicts/solvers/chemistry/TDAC/chemistryProperties.cfg"'
+foamDictionary  testCase/constant/chemistryProperties -entry tabulation -add '{}'
 echo
 echo -e "${YELLOW}Test ISAT_pyJac compilation for DLBFoam-ISAT coupling:${DARKGRAY}"
 foamDictionary -entry tabulation/method -set ISAT_pyJac testCase/constant/chemistryProperties > /dev/null
@@ -61,3 +62,6 @@ fi
 
 cp testCase/constant/thermophysicalProperties.orig testCase/constant/thermophysicalProperties
 rm testCase/constant/thermophysicalProperties.orig
+
+cp testCase/constant/chemistryProperties.orig testCase/constant/chemistryProperties
+rm testCase/constant/chemistryProperties.orig

--- a/tests/validation/pyjacTests/PSRTest/testCase/constant/chemistryProperties
+++ b/tests/validation/pyjacTests/PSRTest/testCase/constant/chemistryProperties
@@ -15,8 +15,6 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-#includeEtc     "caseDicts/solvers/chemistry/TDAC/chemistryPropertiesFlame.cfg"
-
 chemistryType
 {
     solver          ode_pyJac;
@@ -39,16 +37,11 @@ loadbalancing
     log     false;
 }
 
-refmapping{}
-
-reduction
+refmapping
 {
+
 }
 
-tabulation
-{
-    method          none;
-}
 // reactions dictionary is empty - {}
 #include "../../../pyjacTestMechanism/foam/reactions.foam"
 


### PR DESCRIPTION
In standard OpenFOAM, deltaTMin is not updated using solutions from cells that were retireved from the ISAT binary tree. DLBFoam-ISAT implementation was not following this approach. This commit makes the deltaTMin calculation consistent with OpenFOAM-dev, and introduces a small test to ensure consistency.

See https://github.com/Aalto-CFD/DLBFoam/pull/37 for further discussion.