### PR TITLE
    cmake: enforce >=3.5 compatibility for CMake 4

### DIFF
--- a/tests/validation/pyjacTests/pyjacTestMechanism/lib/CMakeLists.txt
+++ b/tests/validation/pyjacTests/pyjacTestMechanism/lib/CMakeLists.txt
@@ -1,4 +1,9 @@
-cmake_minimum_required(VERSION 2.6)
+if(CMAKE_VERSION VERSION_LESS "3.5")
+	cmake_minimum_required(VERSION 3.1)
+else()
+	# Ubuntu 26.04 ships CMake > 4, which requires project compatibility >= 3.5.
+	cmake_minimum_required(VERSION 3.5)
+endif()
 
 project(pyJac)
 
@@ -6,7 +11,7 @@ set(CMAKE_BUILD_TYPE Release)
 
 enable_language(C)
 
-#Note, this is not the most optimized compiler setup.
+# Note, this is not the most optimized compiler setup.
 set(CMAKE_C_FLAGS "-std=c99 -Ofast -fPIC")
 
 include_directories(src)


### PR DESCRIPTION
Title:
Fix pyJac CMake minimum-version handling for CMake 4 (Ubuntu 26.04)

Description:
## Summary
This PR updates the CMake minimum-version logic in CMakeLists.txt to make CMake 4 behavior explicit and documented.

Ubuntu 26.04 ships with CMake > 4, and this requires project compatibility at 3.5 or higher in the modern path.

## Changes
1. Kept/updated minimum-version logic to ensure CMake 4 configure compatibility.
2. Added an explanatory comment in CMakeLists.txt explaining the Ubuntu 26.04 and CMake > 4 requirement.

## Validation
1. Ran configure with CMake 4.x using a clean build directory.
2. Confirmed configuration succeeds with the updated CMakeLists.

## Issue
Closes #56 