### PR TITLE
Default loadbalancing and refmapping to subOrEmptyDict in chemistryProperties

### DIFF
--- a/src/thermophysicalModels/chemistryModel/chemistryModel/loadBalancedChemistryModel/loadBalancedChemistryModel.C
+++ b/src/thermophysicalModels/chemistryModel/chemistryModel/loadBalancedChemistryModel/loadBalancedChemistryModel.C
@@ -35,8 +35,8 @@ Foam::loadBalancedChemistryModel<ThermoType>::
     :
         chemistryModel<ThermoType>(thermo),
         skipSpecies_(this->lookupOrDefault("skipSpecies", false)),
-        balancer_(createBalancer()),
-        mapper_(createMapper(this->thermo())),
+        balancer_(this->subOrEmptyDict("loadbalancing")),
+        mapper_(this->subOrEmptyDict("refmapping"), this->thermo()),
         cpuTimes_
         (
             IOobject
@@ -94,51 +94,6 @@ Foam::loadBalancedChemistryModel<ThermoType>::
 
 
 // * * * * * * * * * * * * * * * Member Functions  * * * * * * * * * * * * * //
-
-template <class ThermoType>
-Foam::mixtureFractionRefMapper
-Foam::loadBalancedChemistryModel<ThermoType>::createMapper
-(
-    const fluidMulticomponentThermo& thermo
-)
-{
-    const IOdictionary chemistryDict_tmp
-        (
-            IOobject
-            (
-                thermo.phasePropertyName("chemistryProperties"),
-                thermo.mesh().time().constant(),
-                thermo.mesh(),
-                IOobject::MUST_READ,
-                IOobject::NO_WRITE,
-                false
-            )
-        );
-
-    return mixtureFractionRefMapper(chemistryDict_tmp, thermo);
-}
-
-
-template <class ThermoType>
-Foam::LoadBalancer
-Foam::loadBalancedChemistryModel<ThermoType>::createBalancer()
-{
-    const IOdictionary chemistryDict_tmp
-        (
-            IOobject
-            (
-                this->thermo().phasePropertyName("chemistryProperties"),
-                this->thermo().mesh().time().constant(),
-                this->thermo().mesh(),
-                IOobject::MUST_READ,
-                IOobject::NO_WRITE,
-                false
-            )
-        );
-
-    return LoadBalancer(chemistryDict_tmp);
-}
-
 
 template <class ThermoType>
 template <class DeltaTType>

--- a/src/thermophysicalModels/chemistryModel/chemistryModel/loadBalancedChemistryModel/loadBalancedChemistryModel.H
+++ b/src/thermophysicalModels/chemistryModel/chemistryModel/loadBalancedChemistryModel/loadBalancedChemistryModel.H
@@ -107,12 +107,6 @@ private:
 
     // Private Member Functions
 
-        //- Create a reference mapper object
-        static mixtureFractionRefMapper createMapper(const fluidMulticomponentThermo& thermo);
-
-        //- Create a load balancer object
-        LoadBalancer createBalancer();
-
         //- Get the list of problems to be solved
         template<class DeltaTType>
         DynamicList<ChemistryProblem> getProblems(const DeltaTType& deltaT);

--- a/src/thermophysicalModels/chemistryModel/loadBalancing/LoadBalancer.H
+++ b/src/thermophysicalModels/chemistryModel/loadBalancing/LoadBalancer.H
@@ -67,10 +67,10 @@ public:
     LoadBalancer() = default;
 
     LoadBalancer(const dictionary& dict)
-        : LoadBalancerBase(), dict_(dict),
-          coeffsDict_(dict.subOrEmptyDict("loadbalancing")),
-          active_(coeffsDict_.lookupOrDefault<Switch>("active", true)),
-          log_(coeffsDict_.lookupOrDefault<Switch>("log", false))
+        : LoadBalancerBase(),
+          dict_(dict),
+          active_(dict_.lookupOrDefault<Switch>("active", true)),
+          log_(dict_.lookupOrDefault<Switch>("log", false))
     {
     }
 
@@ -117,8 +117,6 @@ protected:
 private:
 
     const dictionary dict_;
-
-    const dictionary coeffsDict_;
 
     // Is load balancing active?
     Switch active_;

--- a/src/thermophysicalModels/chemistryModel/loadBalancing/LoadBalancer.H
+++ b/src/thermophysicalModels/chemistryModel/loadBalancing/LoadBalancer.H
@@ -1,8 +1,8 @@
 /*---------------------------------------------------------------------------*\
   =========                 |
-  \\      /  F ield         | DLBFoam: Dynamic Load Balancing 
+  \\      /  F ield         | DLBFoam: Dynamic Load Balancing
    \\    /   O peration     | for fast reactive simulations
-    \\  /    A nd           | 
+    \\  /    A nd           |
      \\/     M anipulation  | 2020, Aalto University, Finland
 -------------------------------------------------------------------------------
 License
@@ -27,7 +27,7 @@ Class
 Description
     Extends the base class LoadBalancerBase by implementing a
     balancing algorithm which tries to set the global mean load to each rank.
-    
+
 SourceFiles
     LoadBalancer.C
 \*---------------------------------------------------------------------------*/
@@ -68,7 +68,7 @@ public:
 
     LoadBalancer(const dictionary& dict)
         : LoadBalancerBase(), dict_(dict),
-          coeffsDict_(dict.subDict("loadbalancing")),
+          coeffsDict_(dict.subOrEmptyDict("loadbalancing")),
           active_(coeffsDict_.lookupOrDefault<Switch>("active", true)),
           log_(coeffsDict_.lookupOrDefault<Switch>("log", false))
     {

--- a/src/thermophysicalModels/chemistryModel/refMapping/mixtureFractionRefMapper.H
+++ b/src/thermophysicalModels/chemistryModel/refMapping/mixtureFractionRefMapper.H
@@ -1,8 +1,8 @@
 /*---------------------------------------------------------------------------*\
   =========                 |
-  \\      /  F ield         | DLBFoam: Dynamic Load Balancing 
+  \\      /  F ield         | DLBFoam: Dynamic Load Balancing
    \\    /   O peration     | for fast reactive simulations
-    \\  /    A nd           | 
+    \\  /    A nd           |
      \\/     M anipulation  | 2020, Aalto University, Finland
 -------------------------------------------------------------------------------
 License
@@ -49,7 +49,7 @@ SourceFiles
 
 See also
     mixtureFraction.H
-    
+
 \*---------------------------------------------------------------------------*/
 
 #ifndef mixtureFractionRefMapper_H
@@ -69,7 +69,7 @@ namespace Foam
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-class mixtureFractionRefMapper 
+class mixtureFractionRefMapper
 {
 
 public:
@@ -77,7 +77,7 @@ public:
 
     mixtureFractionRefMapper(
         const dictionary& dict, const fluidMulticomponentThermo& thermo)
-        : dict_(dict), coeffsDict_(dict.subDict("refmapping")),
+        : dict_(dict), coeffsDict_(dict.subOrEmptyDict("refmapping")),
           active_(coeffsDict_.lookupOrDefault<Switch>("active", false)),
           Ztolerance_(coeffsDict_.lookupOrDefault<scalar>("tolerance", 1e-4)),
           Ttolerance_(coeffsDict_.lookupOrDefault<scalar>("deltaT", VGREAT)),
@@ -120,7 +120,7 @@ private:
 
     // Tolerance for temperature checking (in Kelvins)
     scalar Ttolerance_;
-    
+
     // Mixture fraction object
     mixtureFraction mixture_fraction_;
 };

--- a/src/thermophysicalModels/chemistryModel/refMapping/mixtureFractionRefMapper.H
+++ b/src/thermophysicalModels/chemistryModel/refMapping/mixtureFractionRefMapper.H
@@ -77,16 +77,16 @@ public:
 
     mixtureFractionRefMapper(
         const dictionary& dict, const fluidMulticomponentThermo& thermo)
-        : dict_(dict), coeffsDict_(dict.subOrEmptyDict("refmapping")),
-          active_(coeffsDict_.lookupOrDefault<Switch>("active", false)),
-          Ztolerance_(coeffsDict_.lookupOrDefault<scalar>("tolerance", 1e-4)),
-          Ttolerance_(coeffsDict_.lookupOrDefault<scalar>("deltaT", VGREAT)),
+        : dict_(dict),
+          active_(dict_.lookupOrDefault<Switch>("active", false)),
+          Ztolerance_(dict_.lookupOrDefault<scalar>("tolerance", 1e-4)),
+          Ttolerance_(dict_.lookupOrDefault<scalar>("deltaT", VGREAT)),
           mixture_fraction_()
     {
         if (active())
         {
             mixture_fraction_ = mixtureFraction(
-              coeffsDict_.subDict("mixtureFractionProperties"),
+              dict_.subDict("mixtureFractionProperties"),
               thermo);
         }
     }
@@ -110,7 +110,6 @@ public:
 
 private:
     const dictionary dict_;
-    const dictionary coeffsDict_;
 
     // Is reference mapping active?
     Switch active_;


### PR DESCRIPTION
**Summary**
This PR makes loadbalancing and refmapping optional in chemistryProperties by switching dictionary access to subOrEmptyDict and applying sensible defaults.

**Problem**
At the moment, users must define a refmapping sub-dictionary even when they do not use reference mapping. In practice this often means adding an empty refmapping block just to avoid lookup failures. This is unnecessary friction for the common setup.

**Why this change makes sense**
The most common behavior is:

- Load balancing enabled
- Reference mapping disabled

Requiring explicit empty dictionaries for that default behavior adds boilerplate to every case and makes setup less user-friendly.

**What changed**

- Use subOrEmptyDict for loadbalancing and refmapping lookups.
- If loadbalancing is missing, default to active true.
- If refmapping is missing, default to active false.

**User impact**

- Existing cases with explicit sub-dictionaries continue to work unchanged.
- New and simplified cases can omit loadbalancing and refmapping blocks entirely.
- No need to define an empty refmapping block when refmapping is not used.

**Compatibility**

This is backward compatible and only relaxes configuration requirements while preserving existing behavior for explicit user settings.