### PR TITLE
feat(loadBalancing): split debug/log output and write log data to postProcessing folder

### DIFF
--- a/src/thermophysicalModels/chemistryModel/chemistryModel/loadBalancedChemistryModel/loadBalancedChemistryModel.C
+++ b/src/thermophysicalModels/chemistryModel/chemistryModel/loadBalancedChemistryModel/loadBalancedChemistryModel.C
@@ -73,14 +73,7 @@ Foam::loadBalancedChemistryModel<ThermoType>::
     {
         if(balancer_.log())
         {
-            cpuSolveFile_ = logFile("cpu_solve.out");
-            cpuSolveFile_() << "                  time" << tab
-                            << "           getProblems" << tab
-                            << "           updateState" << tab
-                            << "               balance" << tab
-                            << "           solveBuffer" << tab
-                            << "             unbalance" << tab
-                            << "               rank ID" << endl;
+            initTimingFiles();
         }
 
     }
@@ -234,22 +227,23 @@ Foam::scalar Foam::loadBalancedChemistryModel<ThermoType>::solve
         t_solveBuffer = timer.timeIncrement();
     }
 
-    if(balancer_.log())
+    if(balancer_.debug() && balancer_.active())
     {
-        if(balancer_.active())
-        {
-            balancer_.printState();
-        }
-        cpuSolveFile_() << setw(22)
-                        << this->time().userTimeValue()<<tab
-                        << setw(22) << t_getProblems<<tab
-                        << setw(22) << t_updateState<<tab
-                        << setw(22) << t_balance<<tab
-                        << setw(22) << t_solveBuffer<<tab
-                        << setw(22) << t_unbalance<<tab
-                        << setw(22) << Pstream::myProcNo()
-                        << endl;
+        balancer_.printState();
     }
+
+    if (balancer_.log())
+    {
+        writeTimingStatistics
+        (
+            t_getProblems,
+            t_updateState,
+            t_balance,
+            t_solveBuffer,
+            t_unbalance
+        );
+    }
+
     tabulation_.update();
 
     return updateReactionRates(incomingSolutions);
@@ -380,6 +374,86 @@ Foam::scalar Foam::loadBalancedChemistryModel<ThermoType>::solve
     return min(
         this->solve<UniformField<scalar>>(UniformField<scalar>(deltaT)),
         2 * deltaT);
+}
+
+
+template <class ThermoType>
+void Foam::loadBalancedChemistryModel<ThermoType>::initTimingFiles()
+{
+    if (!Pstream::master())
+    {
+        return;
+    }
+
+    getProblemsFile_ = logFile("getProblems.dat");
+    updateStateFile_ = logFile("updateState.dat");
+    balanceFile_ = logFile("balance.dat");
+    solveBufferFile_ = logFile("solveBuffer.dat");
+    unbalanceFile_ = logFile("unbalance.dat");
+
+    auto writeHeader = [](OFstream& os)
+    {
+        os << "# time";
+        for (label procI = 0; procI < Pstream::nProcs(); ++procI)
+        {
+            os << tab << tab << "proc" << procI;
+        }
+        os << endl;
+    };
+
+    writeHeader(getProblemsFile_());
+    writeHeader(updateStateFile_());
+    writeHeader(balanceFile_());
+    writeHeader(solveBufferFile_());
+    writeHeader(unbalanceFile_());
+}
+
+
+template <class ThermoType>
+void Foam::loadBalancedChemistryModel<ThermoType>::writeTimingStatistics
+(
+    const scalar t_getProblems,
+    const scalar t_updateState,
+    const scalar t_balance,
+    const scalar t_solveBuffer,
+    const scalar t_unbalance
+)
+{
+    List<scalar> myData
+    {
+        t_getProblems,
+        t_updateState,
+        t_balance,
+        t_solveBuffer,
+        t_unbalance
+    };
+
+    List<List<scalar>> gatheredData(Pstream::nProcs(), myData);
+    gatheredData[Pstream::myProcNo()] = myData;
+
+    if (Pstream::parRun())
+    {
+        Pstream::gatherList(gatheredData);
+    }
+
+    if (Pstream::master())
+    {
+        auto writeRow = [&](OFstream& os, const label col)
+        {
+            os << this->time().userTimeValue();
+            for (label procI = 0; procI < Pstream::nProcs(); ++procI)
+            {
+                os << tab << tab << gatheredData[procI][col];
+            }
+            os << endl;
+        };
+
+        writeRow(getProblemsFile_(), 0);
+        writeRow(updateStateFile_(), 1);
+        writeRow(balanceFile_(), 2);
+        writeRow(solveBufferFile_(), 3);
+        writeRow(unbalanceFile_(), 4);
+    }
 }
 
 

--- a/src/thermophysicalModels/chemistryModel/chemistryModel/loadBalancedChemistryModel/loadBalancedChemistryModel.H
+++ b/src/thermophysicalModels/chemistryModel/chemistryModel/loadBalancedChemistryModel/loadBalancedChemistryModel.H
@@ -41,6 +41,8 @@ SourceFiles
 #include "ChemistrySolution.H"
 #include "LoadBalancer.H"
 #include "OFstream.H"
+#include "Pstream.H"
+#include "regionName.H"
 #include "IOmanip.H"
 #include "chemistryModel.H"
 #include "clockTime.H"
@@ -87,8 +89,12 @@ private:
         // 2 -> solved explicitly
         volScalarField refMap_;
 
-        // A file to output the balancing stats
-        autoPtr<OFstream>        cpuSolveFile_;
+        // Files for post-processing timing statistics
+        autoPtr<OFstream> getProblemsFile_;
+        autoPtr<OFstream> updateStateFile_;
+        autoPtr<OFstream> balanceFile_;
+        autoPtr<OFstream> solveBufferFile_;
+        autoPtr<OFstream> unbalanceFile_;
 
         //- Tabulation method
         autoPtr<chemistryTabulationMethod> tabulationPtr_;
@@ -142,6 +148,19 @@ private:
         //  of given type and return the characteristic time
         template<class DeltaTType>
         scalar solve(const DeltaTType& deltaT);
+
+        //- Initialize post-processing files for timing statistics
+        void initTimingFiles();
+
+        //- Gather rank-local timing values and append a new row to output files
+        void writeTimingStatistics
+        (
+            const scalar t_getProblems,
+            const scalar t_updateState,
+            const scalar t_balance,
+            const scalar t_solveBuffer,
+            const scalar t_unbalance
+        );
 
         //- Apply the reference cell mapping
         //TODO: This doesnt belong here and should be in reference cell mapping class.

--- a/src/thermophysicalModels/chemistryModel/chemistryModel/loadBalancedChemistryModel/loadBalancedChemistryModelI.H
+++ b/src/thermophysicalModels/chemistryModel/chemistryModel/loadBalancedChemistryModel/loadBalancedChemistryModelI.H
@@ -34,9 +34,15 @@ inline Foam::autoPtr<Foam::OFstream>
 Foam::loadBalancedChemistryModel<ThermoType>::logFile(
     const word& name) const
 {
-    mkDir(this->mesh().time().path() / "loadBal" / this->group());
-    return autoPtr<OFstream>(new OFstream(
-        this->mesh().time().path() / "loadBal" / this->group() / name));
+    const fileName outDir =
+        this->mesh().time().globalPath()
+      / "postProcessing"
+      / regionName(this->mesh())
+      / "loadBalancing"
+      / this->mesh().time().name()
+    ;
+    mkDir(outDir);
+    return autoPtr<OFstream>(new OFstream(outDir / name));
 }
 
 template <class ThermoType>

--- a/src/thermophysicalModels/chemistryModel/loadBalancing/LoadBalancer.H
+++ b/src/thermophysicalModels/chemistryModel/loadBalancing/LoadBalancer.H
@@ -1,8 +1,8 @@
 /*---------------------------------------------------------------------------*\
   =========                 |
-  \\      /  F ield         | DLBFoam: Dynamic Load Balancing 
+  \\      /  F ield         | DLBFoam: Dynamic Load Balancing
    \\    /   O peration     | for fast reactive simulations
-    \\  /    A nd           | 
+    \\  /    A nd           |
      \\/     M anipulation  | 2020, Aalto University, Finland
 -------------------------------------------------------------------------------
 License
@@ -27,7 +27,7 @@ Class
 Description
     Extends the base class LoadBalancerBase by implementing a
     balancing algorithm which tries to set the global mean load to each rank.
-    
+
 SourceFiles
     LoadBalancer.C
 \*---------------------------------------------------------------------------*/
@@ -70,6 +70,7 @@ public:
         : LoadBalancerBase(), dict_(dict),
           coeffsDict_(dict.subDict("loadbalancing")),
           active_(coeffsDict_.lookupOrDefault<Switch>("active", true)),
+          debug_(coeffsDict_.lookupOrDefault<Switch>("debug", false)),
           log_(coeffsDict_.lookupOrDefault<Switch>("log", false))
     {
     }
@@ -90,6 +91,12 @@ public:
     bool log() const
     {
         return log_;
+    }
+
+    //- Is detailed load balancing state printed to main log?
+    bool debug() const
+    {
+        return debug_;
     }
 
 
@@ -122,6 +129,9 @@ private:
 
     // Is load balancing active?
     Switch active_;
+
+    // Is detailed balancing state output enabled?
+    Switch debug_;
 
     // Is load balancing logged?
     Switch log_;


### PR DESCRIPTION
Implements #60  by splitting loadbalancing/debug (verbose printState) from loadbalancing/log (timing stats), and writing consolidated region-scoped timing outputs in postProcessing (getProblems.dat, updateState.dat, balance.dat, solveBuffer.dat, unbalance.dat) from master after rank gather.