### PR TITLE
remove unnecessary setFields command in Sandia Flame D tutorial

### DIFF
--- a/tutorials/multicomponentFluid/SandiaD_LTS/Allrun_DLB
+++ b/tutorials/multicomponentFluid/SandiaD_LTS/Allrun_DLB
@@ -14,7 +14,6 @@ runApplication chemkinToFoam \
                constant/reactionsGRI constant/thermo.compressibleGasGRI
 
 runApplication blockMesh
-runApplication setFields
 cp -r system/controlDict.orig system/controlDict
 
 #Configure controlDict


### PR DESCRIPTION
This PR removed the unnecessary/deprecated setFields call in the Sandia Flame D tutorial. 

Ideally the change should be made in both 14 and dev branch.